### PR TITLE
AuthenticationPrincipal을 사용해 유저 접근시 쿼리를 두 번 날려야 하는 문제 수정

### DIFF
--- a/aiku/src/main/java/konkuk/aiku/controller/UserController.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/UserController.java
@@ -2,11 +2,13 @@ package konkuk.aiku.controller;
 
 import konkuk.aiku.controller.dto.UserAddDTO;
 import konkuk.aiku.domain.Users;
+import konkuk.aiku.security.UserAdaptor;
 import konkuk.aiku.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,8 +29,8 @@ public class UserController {
     }
 
     @PostMapping("/logout")
-    public void logout(@AuthenticationPrincipal UserDetails users) {
-        String kakaoId = users.getUsername();
+    public void logout(@AuthenticationPrincipal UserAdaptor userAdaptor) {
+        String kakaoId = userAdaptor.getUsername();
         userService.logout(kakaoId);
     }
 

--- a/aiku/src/main/java/konkuk/aiku/controller/dto/UserAddDTO.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/dto/UserAddDTO.java
@@ -46,7 +46,7 @@ public class UserAddDTO {
         );
 
         return Users.builder()
-                .username(username)
+                .personName(username)
                 .phoneNumber(phoneNumber)
                 .kakaoId(kakaoId)
                 .setting(setting)

--- a/aiku/src/main/java/konkuk/aiku/domain/Users.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/Users.java
@@ -23,11 +23,14 @@ public class Users extends TimeEntity implements UserDetails {
     @Column(name = "userId")
     @Setter(value = AccessLevel.NONE)
     private Long id;
-    private String username;
+    private String personName;
     private String phoneNumber;
     private String userImg;
 
     private String kakaoId;
+
+    @Setter
+    private String password;
 
     @Embedded
     private Setting setting;
@@ -49,13 +52,13 @@ public class Users extends TimeEntity implements UserDetails {
 
     private String refreshToken;
 
-    @Override
-    public String getPassword() {
-        return kakaoId;
-    }
-
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    @Override
+    public String getUsername() {
+        return kakaoId;
     }
 
     @Override

--- a/aiku/src/main/java/konkuk/aiku/security/UserAdaptor.java
+++ b/aiku/src/main/java/konkuk/aiku/security/UserAdaptor.java
@@ -1,0 +1,17 @@
+package konkuk.aiku.security;
+
+import konkuk.aiku.domain.Users;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.User;
+
+@Getter
+@Slf4j
+public class UserAdaptor extends User {
+    private Users users;
+
+    public UserAdaptor(Users users) {
+        super(users.getUsername(), users.getPassword(), users.getAuthorities());
+        this.users = users;
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/service/CustomUserDetailsService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/CustomUserDetailsService.java
@@ -2,35 +2,27 @@ package konkuk.aiku.service;
 
 import konkuk.aiku.domain.Users;
 import konkuk.aiku.repository.UsersRepository;
+import konkuk.aiku.security.UserAdaptor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UsersRepository usersRepository;
-    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return usersRepository.findByKakaoId(username)
-                .map(this::createUserDetails)
+        Users users = usersRepository.findByKakaoId(username)
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다."));
-    }
 
-    // 해당하는 User 의 데이터가 존재한다면 UserDetails 객체로 만들어서 return
-    private UserDetails createUserDetails(Users users) {
-        return User.builder()
-                .username(users.getKakaoId())
-                .password(passwordEncoder.encode(users.getPassword()))
-                .roles(users.getRole().name()) // Role -> String 배열
-//                .roles(users.getRoles().toArray(new String[0])) // List -> String 배열
-                .build();
+        return new UserAdaptor(users);
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/service/UserLoginService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/UserLoginService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,8 +33,13 @@ public class UserLoginService {
         UsernamePasswordAuthenticationToken authenticationFilter
                 = new UsernamePasswordAuthenticationToken(kakaoId, kakaoId);
 
+        Authentication authentication = null;
 
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationFilter);
+        try {
+            authentication = authenticationManagerBuilder.getObject().authenticate(authenticationFilter);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 

--- a/aiku/src/main/java/konkuk/aiku/service/UserService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/UserService.java
@@ -4,6 +4,7 @@ import konkuk.aiku.domain.Users;
 import konkuk.aiku.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,9 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UsersRepository usersRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public Users save(Users users) {
+        users.setPassword(passwordEncoder.encode(users.getKakaoId()));
         return usersRepository.save(users);
     }
 

--- a/aiku/src/main/resources/application.yml
+++ b/aiku/src/main/resources/application.yml
@@ -16,8 +16,10 @@ spring:
 jwt:
   secret: f48d729a72445f378eb3be26525615782ddd1555889c9997d41ddab82d560c51
 #  공개 금지 (공개시 ignore에 추가 필요)
-
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type : trace
+#logging:
+#  level:
+#    root: trace
 #  org.hibernate.type: trace


### PR DESCRIPTION
### AuthenticationPrincipal을 사용해 유저 접근시 쿼리를 두 번 날려야 하는 문제 수정
컨트롤러에서
@AuthenticationPrincipal UserAdaptor userAdaptor
로 받아서 userAdaptor.getUsers() 하면
따로 쿼리를 보내지 않고도 객체에 직접 접근이 가능합니다.

### Users에서 username 필드가 Security에서 제공하는 UserDetails와 겹치는 문제 해결
기존 필드 username -> personName으로 수정하였습니다.