### PR TITLE
스케줄 종료 시 베팅 확정 로직 및 베팅 상태 추가

### DIFF
--- a/aiku/src/main/java/konkuk/aiku/controller/BettingController.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/BettingController.java
@@ -36,6 +36,13 @@ public class BettingController {
         return SuccessResponseDto.getResponseEntity(bettingId, SuccessMessage.ADD_SUCCESS, HttpStatus.OK);
     }
 
+    @PatchMapping("/{bettingId}")
+    public ResponseEntity<SuccessResponseDto> acceptBetting(@PathVariable Long bettingId) {
+        Long updateBettingId = bettingService.acceptBetting(bettingId);
+
+        return SuccessResponseDto.getResponseEntity(updateBettingId, SuccessMessage.ADD_SUCCESS, HttpStatus.OK);
+    }
+
     @GetMapping("/{bettingId}")
     public ResponseEntity<BettingResponseDto> getBetting(@PathVariable Long bettingId) {
 
@@ -45,18 +52,19 @@ public class BettingController {
         return new ResponseEntity(bettingResponseDto, HttpStatus.OK);
     }
 
-    @PatchMapping("/{bettingId}")
-    public ResponseEntity<SuccessResponseDto> modifyBetting(
-            @AuthenticationPrincipal UserAdaptor userAdaptor,
-            @PathVariable Long scheduleId, @PathVariable Long bettingId,
-            @RequestBody BettingModifyDto bettingModifyDto) {
-        BettingServiceDto bettingServiceDto = bettingModifyDto.toServiceDto();
-
-        Long updateId = bettingService.updateBetting(userAdaptor.getUsers(), scheduleId, bettingId, bettingServiceDto);
-
-        return SuccessResponseDto.getResponseEntity(updateId, SuccessMessage.MODIFY_SUCCESS, HttpStatus.OK);
-
-    }
+    // 베팅 업데이트 미사용(Deprecated)
+//    @PatchMapping("/{bettingId}")
+//    public ResponseEntity<SuccessResponseDto> modifyBetting(
+//            @AuthenticationPrincipal UserAdaptor userAdaptor,
+//            @PathVariable Long scheduleId, @PathVariable Long bettingId,
+//            @RequestBody BettingModifyDto bettingModifyDto) {
+//        BettingServiceDto bettingServiceDto = bettingModifyDto.toServiceDto();
+//
+//        Long updateId = bettingService.updateBetting(userAdaptor.getUsers(), scheduleId, bettingId, bettingServiceDto);
+//
+//        return SuccessResponseDto.getResponseEntity(updateId, SuccessMessage.MODIFY_SUCCESS, HttpStatus.OK);
+//
+//    }
 
     @DeleteMapping("/{bettingId}")
     public ResponseEntity<SuccessResponseDto> deleteBetting(

--- a/aiku/src/main/java/konkuk/aiku/domain/Betting.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/Betting.java
@@ -33,16 +33,20 @@ public class Betting extends TimeEntity{
     @Enumerated
     private BettingType bettingType; // RACING, BETTING
 
+    @Enumerated
+    private BettingStatus bettingStatus;
+
     public void updateBettingResult(ResultType resultType) {
         this.resultType = resultType;
     }
 
     @Builder
-    public Betting(Users bettor, Users targetUser, Schedule schedule, int point, BettingType bettingType) {
+    public Betting(Users bettor, Users targetUser, Schedule schedule, int point, BettingType bettingType, BettingStatus bettingStatus) {
         this.bettor = bettor;
         this.targetUser = targetUser;
         this.schedule = schedule;
         this.point = point;
         this.bettingType = bettingType;
+        this.bettingStatus = bettingStatus;
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/domain/Betting.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/Betting.java
@@ -33,6 +33,10 @@ public class Betting extends TimeEntity{
     @Enumerated
     private BettingType bettingType; // RACING, BETTING
 
+    public void updateBettingResult(ResultType resultType) {
+        this.resultType = resultType;
+    }
+
     @Builder
     public Betting(Users bettor, Users targetUser, Schedule schedule, int point, BettingType bettingType) {
         this.bettor = bettor;

--- a/aiku/src/main/java/konkuk/aiku/domain/BettingStatus.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/BettingStatus.java
@@ -1,0 +1,5 @@
+package konkuk.aiku.domain;
+
+public enum BettingStatus {
+    WAIT, ACCEPT, DONE
+}

--- a/aiku/src/main/java/konkuk/aiku/domain/PointChangeType.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/PointChangeType.java
@@ -1,0 +1,5 @@
+package konkuk.aiku.domain;
+
+public enum PointChangeType {
+    PLUS, MINUS
+}

--- a/aiku/src/main/java/konkuk/aiku/domain/ResultType.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/ResultType.java
@@ -1,5 +1,5 @@
 package konkuk.aiku.domain;
 
 public enum ResultType {
-    WIN, LOSE
+    WIN, LOSE, DRAW
 }

--- a/aiku/src/main/java/konkuk/aiku/domain/UserPoint.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/UserPoint.java
@@ -1,10 +1,11 @@
 package konkuk.aiku.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserPoint extends TimeEntity{
 
     @Id
@@ -19,5 +20,16 @@ public class UserPoint extends TimeEntity{
     private int point;
 
     @Enumerated
+    private PointChangeType pointChangeType;
+
+    @Enumerated
     private PointType pointType;
+
+    @Builder
+    public UserPoint(Users user, int point, PointChangeType pointChangeType, PointType pointType) {
+        this.user = user;
+        this.point = point;
+        this.pointChangeType = pointChangeType;
+        this.pointType = pointType;
+    }
 }

--- a/aiku/src/main/java/konkuk/aiku/domain/Users.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/Users.java
@@ -1,7 +1,6 @@
 package konkuk.aiku.domain;
 
 import jakarta.persistence.*;
-import konkuk.aiku.controller.dto.UserUpdateDto;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -72,5 +71,13 @@ public class Users extends TimeEntity {
     public void setFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
         this.fcmTokenCreateAt = LocalDateTime.now();
+    }
+
+    public void plusPoint(int point) {
+        this.point += point;
+    }
+
+    public void minusPoint(int point) {
+        this.point -= point;
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/event/UserPointChangeEvent.java
+++ b/aiku/src/main/java/konkuk/aiku/event/UserPointChangeEvent.java
@@ -1,0 +1,19 @@
+package konkuk.aiku.event;
+
+import konkuk.aiku.domain.PointChangeType;
+import konkuk.aiku.domain.PointType;
+import konkuk.aiku.domain.Users;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserPointChangeEvent {
+    private final Users user;
+    private final int point;
+    private final PointType pointType;
+    private final PointChangeType pointChangeType;
+    private final LocalDateTime eventTime;
+}

--- a/aiku/src/main/java/konkuk/aiku/event/UserPointEventHandler.java
+++ b/aiku/src/main/java/konkuk/aiku/event/UserPointEventHandler.java
@@ -1,0 +1,27 @@
+package konkuk.aiku.event;
+
+import konkuk.aiku.domain.Users;
+import konkuk.aiku.service.UserPointService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserPointEventHandler {
+    private final UserPointService userPointService;
+
+
+    // Point 이동 이벤트 발생
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void userPointChangeEvent(UserPointChangeEvent event) {
+        Users user = event.getUser();
+
+        userPointService.addUserPoint(user, event.getPoint(), event.getPointChangeType(), event.getPointType());
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/event/UserPointEventPublisher.java
+++ b/aiku/src/main/java/konkuk/aiku/event/UserPointEventPublisher.java
@@ -1,0 +1,20 @@
+package konkuk.aiku.event;
+
+import konkuk.aiku.domain.PointChangeType;
+import konkuk.aiku.domain.PointType;
+import konkuk.aiku.domain.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserPointEventPublisher {
+    private final ApplicationEventPublisher publisher;
+
+    public void userPointChangeEvent(Users users, int point, PointType pointType, PointChangeType pointChangeType, LocalDateTime eventTime) {
+        publisher.publishEvent(new UserPointChangeEvent(users, point, pointType, pointChangeType, eventTime));
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/service/BettingService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/BettingService.java
@@ -142,8 +142,10 @@ public class BettingService {
      * 스케줄 종료시 베팅 결과 생성 로직
      * @param betting 결과 생성을 원하는 베팅
      * @return 베팅 아이디
+     * TODO: Schedule 종료 시 해당 메소드 실행
      */
-    public Long setBettingResult(Betting betting) {
+    public Long setBettingResult(Long bettingId) {
+        Betting betting = findBettingById(bettingId);
         Users bettor = betting.getBettor();
         Users targetUser = betting.getTargetUser();
 

--- a/aiku/src/main/java/konkuk/aiku/service/BettingService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/BettingService.java
@@ -68,13 +68,39 @@ public class BettingService {
                 .point(bettingServiceDto.getPoint())
                 .schedule(userSchedule.getSchedule())
                 .bettingType(bettingServiceDto.getBettingType())
+                .bettingStatus(BettingStatus.WAIT)
                 .build();
 
         bettingRepository.save(betting);
 
+        // TODO : 스케줄러 로직 (1분)
+        // TODO : 베팅 상대에게 알림 메시지
+
         return betting.getId();
     }
 
+    public Long acceptBetting(Long bettingId) {
+        Betting betting = findBettingById(bettingId);
+        betting.setBettingStatus(BettingStatus.ACCEPT);
+
+        // TODO : 베팅 주인에게 수락 알림 메시지
+
+        return betting.getId();
+    }
+
+    // TODO : 베팅 미수락 시 베팅 삭제 로직
+    public Long deleteBettingById(Long bettingId) {
+        Betting betting = findBettingById(bettingId);
+        // 베팅이 수락되지 않은 경우
+        if (!betting.getBettingStatus().equals(BettingStatus.ACCEPT)) {
+            bettingRepository.deleteById(bettingId);
+        }
+
+        return bettingId;
+    }
+
+
+    // 베팅 업데이트 로직 미사용(Deprecated)
     public Long updateBetting(Users users, Long scheduleId, Long bettingId, BettingServiceDto bettingServiceDto) {
         Optional<UserSchedule> userInSchedule = findUserInSchedule(users.getId(), scheduleId);
 
@@ -161,6 +187,7 @@ public class BettingService {
         }
 
         betting.updateBettingResult(resultType);
+        betting.setBettingStatus(BettingStatus.DONE);
 
         return betting.getId();
     }

--- a/aiku/src/main/java/konkuk/aiku/service/BettingService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/BettingService.java
@@ -1,9 +1,7 @@
 package konkuk.aiku.service;
 
-import konkuk.aiku.domain.Betting;
-import konkuk.aiku.domain.BettingType;
-import konkuk.aiku.domain.UserSchedule;
-import konkuk.aiku.domain.Users;
+import konkuk.aiku.domain.*;
+import konkuk.aiku.event.UserPointEventPublisher;
 import konkuk.aiku.exception.ErrorCode;
 import konkuk.aiku.exception.NoAthorityToAccessException;
 import konkuk.aiku.exception.NoSuchEntityException;
@@ -16,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,6 +28,7 @@ public class BettingService {
     private final BettingRepository bettingRepository;
     private final ScheduleRepository scheduleRepository;
     private final UsersRepository usersRepository;
+    private final UserPointEventPublisher userPointEventPublisher;
 
 
     private Optional<UserSchedule> findUserInSchedule(Long userId, Long scheduleId) {
@@ -109,5 +109,59 @@ public class BettingService {
         return bettings.stream()
                 .map(BettingServiceDto::toServiceDto)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 이벤트 발생 메서드
+     * 스케줄 종료시 베팅 결과 생성 로직
+     * @param betting 결과 생성을 원하는 베팅
+     * @return 베팅 아이디
+     */
+    public Long setBettingResult(Betting betting) {
+        Users bettor = betting.getBettor();
+        Users targetUser = betting.getTargetUser();
+
+        Schedule schedule = betting.getSchedule();
+        List<UserArrivalData> userArrivalDatas = schedule.getUserArrivalDatas();
+        UserArrivalData bettorArrivalData = userArrivalDatas.stream().filter(u -> u.getUser().getId() == bettor.getId())
+                .findAny().orElseThrow(() -> new NoSuchEntityException(ErrorCode.NO_SUCH_USER));
+        UserArrivalData targetArrivalDate = userArrivalDatas.stream().filter(u -> u.getUser().getId() == targetUser.getId())
+                .findAny().orElseThrow(() -> new NoSuchEntityException(ErrorCode.NO_SUCH_USER));
+
+        LocalDateTime bettorTime = bettorArrivalData.getArrivalTime();
+        LocalDateTime targetTime = targetArrivalDate.getArrivalTime();
+
+        ResultType resultType;
+        int point = betting.getPoint();
+
+        // 플러스 포인트 : 베팅 걸린 시점에서 베팅 포인트 가져갔기 때문에 2배로 더해준다.
+        int plusPoint = point * 2;
+
+        if (bettorTime.isBefore(targetTime)) {
+            resultType = ResultType.WIN;
+            // 베팅 건 사람 플러스 포인트
+            bettor.plusPoint(plusPoint);
+
+            userPointEventPublisher.userPointChangeEvent(bettor, plusPoint, PointType.BETTING, PointChangeType.PLUS, LocalDateTime.now());
+        } else if (bettorTime.isAfter(targetTime)) {
+            resultType = ResultType.LOSE;
+            // 베팅 걸린 사람 플러스 포인트
+            targetUser.plusPoint(plusPoint);
+
+            userPointEventPublisher.userPointChangeEvent(targetUser, plusPoint, PointType.BETTING, PointChangeType.PLUS, LocalDateTime.now());
+        } else {
+            resultType = ResultType.DRAW;
+            // 베팅 건 금액 돌려주기
+            bettor.plusPoint(point);
+            targetUser.plusPoint(point);
+
+            userPointEventPublisher.userPointChangeEvent(bettor, point, PointType.BETTING, PointChangeType.PLUS, LocalDateTime.now());
+            userPointEventPublisher.userPointChangeEvent(targetUser, point, PointType.BETTING, PointChangeType.PLUS, LocalDateTime.now());
+
+        }
+
+        betting.updateBettingResult(resultType);
+
+        return betting.getId();
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/service/UserPointService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/UserPointService.java
@@ -1,0 +1,30 @@
+package konkuk.aiku.service;
+
+import konkuk.aiku.domain.PointChangeType;
+import konkuk.aiku.domain.PointType;
+import konkuk.aiku.domain.UserPoint;
+import konkuk.aiku.domain.Users;
+import konkuk.aiku.repository.UserPointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserPointService {
+    private final UserPointRepository userPointRepository;
+
+    public Long addUserPoint(Users users, int point, PointChangeType pointChangeType, PointType pointType) {
+        UserPoint userPoint = UserPoint.builder()
+                .user(users)
+                .point(point)
+                .pointChangeType(pointChangeType)
+                .pointType(pointType)
+                .build();
+
+        UserPoint save = userPointRepository.save(userPoint);
+
+        return save.getId();
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/service/dto/BettingServiceDto.java
+++ b/aiku/src/main/java/konkuk/aiku/service/dto/BettingServiceDto.java
@@ -2,6 +2,7 @@ package konkuk.aiku.service.dto;
 
 import jakarta.persistence.*;
 import konkuk.aiku.domain.Betting;
+import konkuk.aiku.domain.BettingStatus;
 import konkuk.aiku.domain.BettingType;
 import konkuk.aiku.domain.ResultType;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class BettingServiceDto {
     private int point;
     private ResultType resultType; // WIN, LOSE
     private BettingType bettingType; // RACING, BETTING
+    private BettingStatus bettingStatus;
 
     public static BettingServiceDto toServiceDto(Betting betting) {
         UserSimpleServiceDto bettorDto = UserSimpleServiceDto.toDto(betting.getBettor());
@@ -32,6 +34,7 @@ public class BettingServiceDto {
                 .point(betting.getPoint())
                 .resultType(betting.getResultType())
                 .bettingType(betting.getBettingType())
+                .bettingStatus(betting.getBettingStatus())
                 .build();
     }
 }


### PR DESCRIPTION
1. 스케줄 종료 시 베팅 확정 로직
- 스케줄 종료 시 BettingService에 있는 setBettingResult 메소드 실행
- 영속성 관리를 위해 Id로 파라미터 변경

2. Betting 상태 추가
- 베팅 수락을 기다리기 위해 베팅 상태를 추가
- 베팅 요청 및 수락 시 상대에게 알림 기능 추가 필요
- 베팅 수락 기다리기 위한 스케줄러 이벤트 추가 필요