### PR TITLE
그룹 멤버들의 누적 지각 조회 기능 추가

### DIFF
--- a/aiku/src/main/java/konkuk/aiku/controller/AlarmController.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/AlarmController.java
@@ -1,5 +1,6 @@
 package konkuk.aiku.controller;
 
+import com.google.api.client.http.HttpResponse;
 import jakarta.validation.Valid;
 import konkuk.aiku.controller.dto.EmojiMessageDto;
 import konkuk.aiku.controller.dto.RealTimeLocationDto;
@@ -11,6 +12,7 @@ import konkuk.aiku.security.UserAdaptor;
 import konkuk.aiku.service.AlarmService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -53,19 +55,21 @@ public class AlarmController {
     }
 
     @PostMapping("/schedules/{scheduleId}/location/arrival")
-    public void userArrival(@PathVariable Long scheduleId,
-                            @RequestBody @Valid UserArrivalDto userArrivalDto,
-                            @AuthenticationPrincipal UserAdaptor userAdaptor){
+    public ResponseEntity userArrival(@PathVariable Long scheduleId,
+                                    @RequestBody @Valid UserArrivalDto userArrivalDto,
+                                    @AuthenticationPrincipal UserAdaptor userAdaptor){
         Users user = userAdaptor.getUsers();
 
         alarmService.receiveUserArrival(user, scheduleId, userArrivalDto.getArrivalTime());
+        return new ResponseEntity(HttpStatus.OK);
     }
 
     @PostMapping("/schedules/{scheduleId}/emoji")
-    public void emojiSend(@PathVariable Long scheduleId,
+    public ResponseEntity emojiSend(@PathVariable Long scheduleId,
                           @RequestBody @Valid EmojiMessageDto emojiMessageDto,
                           @AuthenticationPrincipal UserAdaptor userAdaptor) {
         Users user = userAdaptor.getUsers();
         alarmService.sendEmojiToUser(user, scheduleId, emojiMessageDto);
+        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/controller/GroupController.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/GroupController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import static konkuk.aiku.controller.dto.SuccessResponseDto.SuccessMessage.*;
 
-@Controller
+@RestController
 @RequestMapping("/groups")
 @RequiredArgsConstructor
 @Slf4j

--- a/aiku/src/main/java/konkuk/aiku/controller/GroupController.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/GroupController.java
@@ -1,13 +1,11 @@
 package konkuk.aiku.controller;
 
 import jakarta.validation.Valid;
-import konkuk.aiku.controller.dto.GroupDto;
-import konkuk.aiku.controller.dto.GroupListResponseDto;
-import konkuk.aiku.controller.dto.GroupResponseDto;
-import konkuk.aiku.controller.dto.SuccessResponseDto;
+import konkuk.aiku.controller.dto.*;
 import konkuk.aiku.domain.Users;
 import konkuk.aiku.security.UserAdaptor;
 import konkuk.aiku.service.GroupService;
+import konkuk.aiku.service.dto.AnalyticsLateRatingServiceDto;
 import konkuk.aiku.service.dto.GroupDetailServiceDto;
 import konkuk.aiku.service.dto.GroupListServiceDto;
 import konkuk.aiku.service.dto.GroupServiceDto;
@@ -67,7 +65,7 @@ public class GroupController {
         GroupListServiceDto serviceDto = groupService.findGroupList(user);
 
         GroupListResponseDto responseDto = GroupListResponseDto.toDto(serviceDto);
-        return new ResponseEntity<GroupListResponseDto>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @GetMapping("/{groupId}")
@@ -78,7 +76,7 @@ public class GroupController {
         GroupDetailServiceDto serviceDTO = groupService.findGroupDetail(user, groupId);
 
         GroupResponseDto responseDto = GroupResponseDto.toDto(serviceDTO);
-        return new ResponseEntity<GroupResponseDto>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @PostMapping("/{groupId}/enter")
@@ -98,9 +96,12 @@ public class GroupController {
     }
 
     @GetMapping("/{groupId}/analytics/late")
-    public void analyticsLateRanking(@PathVariable Long groupId,
+    public ResponseEntity<AnalyticsLateRatingResponseDto> analyticsLateRanking(@PathVariable Long groupId,
                                      @AuthenticationPrincipal UserAdaptor userAdaptor){
         Users user = userAdaptor.getUsers();
-        
+        AnalyticsLateRatingServiceDto serviceDto = groupService.getLateAnalytics(user, groupId);
+
+        AnalyticsLateRatingResponseDto responseDto = AnalyticsLateRatingResponseDto.toDto(serviceDto);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/controller/GroupController.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/GroupController.java
@@ -96,4 +96,11 @@ public class GroupController {
         Long exitId = groupService.exitGroup(user, groupId);
         return SuccessResponseDto.getResponseEntity(exitId, EXIT_SUCCESS, HttpStatus.OK);
     }
+
+    @GetMapping("/{groupId}/analytics/late")
+    public void analyticsLateRanking(@PathVariable Long groupId,
+                                     @AuthenticationPrincipal UserAdaptor userAdaptor){
+        Users user = userAdaptor.getUsers();
+        
+    }
 }

--- a/aiku/src/main/java/konkuk/aiku/controller/dto/AnalyticsLateRatingResponseDto.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/dto/AnalyticsLateRatingResponseDto.java
@@ -1,0 +1,24 @@
+package konkuk.aiku.controller.dto;
+
+import konkuk.aiku.service.dto.AnalyticsLateRatingServiceDto;
+import konkuk.aiku.service.dto.AnalyticsLateServiceDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Getter
+@AllArgsConstructor
+public class AnalyticsLateRatingResponseDto{
+
+    List<AnalyticsLateResponseDto> data = new ArrayList<>();
+
+    public static AnalyticsLateRatingResponseDto toDto(AnalyticsLateRatingServiceDto serviceDto){
+        List<AnalyticsLateResponseDto> dataDto = serviceDto.getData().stream()
+                .map(AnalyticsLateResponseDto::toDto)
+                .toList();
+        return new AnalyticsLateRatingResponseDto(dataDto);
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/controller/dto/AnalyticsLateResponseDto.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/dto/AnalyticsLateResponseDto.java
@@ -1,0 +1,15 @@
+package konkuk.aiku.controller.dto;
+
+import konkuk.aiku.service.dto.AnalyticsLateServiceDto;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class AnalyticsLateResponseDto{
+    private UserSimpleResponseDto user;
+    private int totalLateMinute;
+
+    public static AnalyticsLateResponseDto toDto(AnalyticsLateServiceDto serviceDto){
+
+        return new AnalyticsLateResponseDto(UserSimpleResponseDto.toDto(serviceDto.getUser()), serviceDto.getTotalLateMinute());
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/controller/dto/AnalyticsLateResponseDto.java
+++ b/aiku/src/main/java/konkuk/aiku/controller/dto/AnalyticsLateResponseDto.java
@@ -2,14 +2,15 @@ package konkuk.aiku.controller.dto;
 
 import konkuk.aiku.service.dto.AnalyticsLateServiceDto;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class AnalyticsLateResponseDto{
     private UserSimpleResponseDto user;
     private int totalLateMinute;
 
     public static AnalyticsLateResponseDto toDto(AnalyticsLateServiceDto serviceDto){
-
         return new AnalyticsLateResponseDto(UserSimpleResponseDto.toDto(serviceDto.getUser()), serviceDto.getTotalLateMinute());
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/domain/Schedule.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/Schedule.java
@@ -27,7 +27,7 @@ public class Schedule extends TimeEntity{
     private Location location;
     private LocalDateTime scheduleTime;
 
-    @Enumerated
+    @Enumerated(value = EnumType.STRING)
     private ScheduleStatus status;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)

--- a/aiku/src/main/java/konkuk/aiku/domain/Schedule.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/Schedule.java
@@ -73,7 +73,7 @@ public class Schedule extends TimeEntity{
     }
 
     public void addUserArrivalData(Users user, LocalDateTime arrivalTime){
-        UserArrivalData userArrivalData = UserArrivalData.createUserArrivalData(user, this, arrivalTime);
+        UserArrivalData userArrivalData = UserArrivalData.createUserArrivalData(user, this.group, this, arrivalTime);
         userArrivalDatas.add(userArrivalData);
     }
 

--- a/aiku/src/main/java/konkuk/aiku/domain/UserArrivalData.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/UserArrivalData.java
@@ -65,6 +65,6 @@ public class UserArrivalData extends TimeEntity{
 
     //==편의 메서드==
     private void setTimeDifference(LocalDateTime scheduleTime){
-        timeDifference = (int) Duration.between(scheduleTime, arrivalTime).toMinutes();
+        timeDifference = (int) Duration.between(arrivalTime, scheduleTime).toMinutes();
     }
 }

--- a/aiku/src/main/java/konkuk/aiku/domain/UserArrivalData.java
+++ b/aiku/src/main/java/konkuk/aiku/domain/UserArrivalData.java
@@ -24,6 +24,10 @@ public class UserArrivalData extends TimeEntity{
     private Users user;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "groupId")
+    private Groups group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scheduleId")
     private Schedule schedule;
     private LocalDateTime arrivalTime;
@@ -45,15 +49,16 @@ public class UserArrivalData extends TimeEntity{
     })
     private Location endLocation;
 
-    private UserArrivalData(Users user, Schedule schedule, LocalDateTime arrivalTime) {
+    public UserArrivalData(Users user, Groups group, Schedule schedule, LocalDateTime arrivalTime) {
         this.user = user;
+        this.group = group;
         this.schedule = schedule;
         this.arrivalTime = arrivalTime;
     }
 
     //==생성 메서드==
-    public static UserArrivalData createUserArrivalData(Users user, Schedule schedule, LocalDateTime arrivalTime){
-        UserArrivalData userArrivalData = new UserArrivalData(user, schedule, arrivalTime);
+    public static UserArrivalData createUserArrivalData(Users user, Groups group, Schedule schedule, LocalDateTime arrivalTime){
+        UserArrivalData userArrivalData = new UserArrivalData(user, group, schedule, arrivalTime);
         userArrivalData.setTimeDifference(schedule.getScheduleTime());
         return userArrivalData;
     }

--- a/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepository.java
+++ b/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepository.java
@@ -1,6 +1,7 @@
 package konkuk.aiku.repository;
 
 import konkuk.aiku.domain.Schedule;
+import konkuk.aiku.domain.UserArrivalData;
 import konkuk.aiku.domain.UserSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepositoryCustom.java
+++ b/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepositoryCustom.java
@@ -9,6 +9,7 @@ public interface ScheduleRepositoryCustom {
     Optional<UserSchedule> findUserScheduleByUserIdAndScheduleId(Long userId, Long scheduleId);
     List<Users> findWaitUsersInSchedule(Long groupId, List<UserSchedule> acceptUsers);
     Optional<UserArrivalData> findUserArrivalDataByUserIdAndScheduleId(Long userId, Long scheduleId);
+    List<UserArrivalData> findUserArrivalDatasWithUserByGroupId(Long groupId);
     List<Schedule> findScheduleByGroupId(Long GroupId, String startTime, String endTime, ScheduleStatus status);
     List<UserSchedule> findUserScheduleByUserId(Long userId, String startTime, String endTime, ScheduleStatus status);
 }

--- a/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepositoryCustomImpl.java
+++ b/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepositoryCustomImpl.java
@@ -62,6 +62,16 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom{
     }
 
     @Override
+    public List<UserArrivalData> findUserArrivalDatasWithUserByGroupId(Long groupId) {
+        return entityManager.createQuery(
+                "SELECT uad" +
+                        " FROM UserArrivalData uad" +
+                        " JOIN FETCH uad.user u" +
+                        " WHERE uad.group.id = :groupId", UserArrivalData.class
+        ).getResultList();
+    }
+
+    @Override
     public List<Schedule> findScheduleByGroupId(Long groupId, String startTime, String endTime, ScheduleStatus status) {
         return jpaQueryFactory
                 .selectFrom(qSchedule)
@@ -112,4 +122,6 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom{
         if (type == 0) return qSchedule.status.eq(status);
         else return qUserSchedule.schedule.status.eq(status);
     }
+
+
 }

--- a/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepositoryCustomImpl.java
+++ b/aiku/src/main/java/konkuk/aiku/repository/ScheduleRepositoryCustomImpl.java
@@ -64,11 +64,13 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom{
     @Override
     public List<UserArrivalData> findUserArrivalDatasWithUserByGroupId(Long groupId) {
         return entityManager.createQuery(
-                "SELECT uad" +
-                        " FROM UserArrivalData uad" +
-                        " JOIN FETCH uad.user u" +
-                        " WHERE uad.group.id = :groupId", UserArrivalData.class
-        ).getResultList();
+                        "SELECT uad" +
+                                " FROM UserArrivalData uad" +
+                                " JOIN FETCH uad.user u" +
+                                " WHERE uad.group.id = :groupId", UserArrivalData.class
+                )
+                .setParameter("groupId", groupId)
+                .getResultList();
     }
 
     @Override

--- a/aiku/src/main/java/konkuk/aiku/service/GroupService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/GroupService.java
@@ -29,8 +29,8 @@ public class GroupService {
     @Transactional
     public Long addGroup(Users user, GroupServiceDto groupDto){
         Groups group = Groups.createGroups(user, groupDto.getGroupName(), groupDto.getDescription());
-        groupsRepository.save(group);
 
+        groupsRepository.save(group);
         return group.getId();
     }
 
@@ -56,6 +56,7 @@ public class GroupService {
 
     public GroupDetailServiceDto findGroupDetail(Users user, Long groupId) {
         Groups group = findGroupById(groupId);
+
         checkUserInGroup(user, group);
 
         List<UserGroup> userGroups = groupsRepository.findUserGroupWithUser(groupId);
@@ -106,6 +107,7 @@ public class GroupService {
         Groups group = findGroupById(groupId);
 
         UserGroup userGroup = checkUserInGroup(user, group);
+
         group.deleteUser(userGroup);
         groupsRepository.downGroupUserCount(groupId);
         return groupId;

--- a/aiku/src/main/java/konkuk/aiku/service/ScheduleService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/ScheduleService.java
@@ -156,7 +156,7 @@ public class ScheduleService {
 
     //==유저 도착 이벤트==
     @Transactional
-    public boolean createUserArrivalData(Long userId, Long scheduleId, LocalDateTime arriveTime){
+    public boolean createUserArrivalData(Long userId, Long groupId, Long scheduleId, LocalDateTime arriveTime){
         Users user = findUserById(userId);
 
         if(checkUserAlreadyArrive(userId, scheduleId)) return false;

--- a/aiku/src/main/java/konkuk/aiku/service/ScheduleService.java
+++ b/aiku/src/main/java/konkuk/aiku/service/ScheduleService.java
@@ -156,7 +156,7 @@ public class ScheduleService {
 
     //==유저 도착 이벤트==
     @Transactional
-    public boolean createUserArrivalData(Long userId, Long groupId, Long scheduleId, LocalDateTime arriveTime){
+    public boolean createUserArrivalData(Long userId, Long scheduleId, LocalDateTime arriveTime){
         Users user = findUserById(userId);
 
         if(checkUserAlreadyArrive(userId, scheduleId)) return false;

--- a/aiku/src/main/java/konkuk/aiku/service/dto/AnalyticsLateRatingServiceDto.java
+++ b/aiku/src/main/java/konkuk/aiku/service/dto/AnalyticsLateRatingServiceDto.java
@@ -1,0 +1,13 @@
+package konkuk.aiku.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AnalyticsLateRatingServiceDto {
+
+    List<AnalyticsLateServiceDto> data;
+}

--- a/aiku/src/main/java/konkuk/aiku/service/dto/AnalyticsLateServiceDto.java
+++ b/aiku/src/main/java/konkuk/aiku/service/dto/AnalyticsLateServiceDto.java
@@ -1,0 +1,17 @@
+package konkuk.aiku.service.dto;
+
+import konkuk.aiku.domain.Users;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnalyticsLateServiceDto {
+    private UserSimpleServiceDto user;
+    private int totalLateMinute;
+
+    public static AnalyticsLateServiceDto createDto(Users arrivalUser, Integer totalLateTime){
+        return new AnalyticsLateServiceDto(UserSimpleServiceDto.toDto(arrivalUser), totalLateTime);
+    }
+}

--- a/aiku/src/main/java/konkuk/aiku/service/dto/SettingServiceDto.java
+++ b/aiku/src/main/java/konkuk/aiku/service/dto/SettingServiceDto.java
@@ -23,4 +23,9 @@ public class SettingServiceDto {
                 .build();
         return dto;
     }
+
+    @Getter
+    public static class AnalyticsLateRatingServiceDto {
+
+    }
 }


### PR DESCRIPTION
그룹 멤버들의 누적 지각 조회 기능 추가
- 그룹 분석 페이지에 해당하는 rest api
- GroupService에 있는게 맞는지 고민할 필요가 있음.
Schedule에그리게잇에 종속되어 있는 UserArrivalData엔티티 리스트를 조회.
ScheduleService에 있어야 할까?